### PR TITLE
added sherlock domains

### DIFF
--- a/data.json
+++ b/data.json
@@ -584,6 +584,14 @@
         "llms-txt-tokens": 523
     },
     {
+        "product": "Sherlock Domains",
+        "website": "https://sherlockdomains.com/",
+        "llms-full-txt": "https://www.sherlockdomains.com/llms-full.txt",
+        "llms-full-txt-tokens": 3803,
+        "llms-txt": "https://www.sherlockdomains.com/llms.txt",
+        "llms-txt-tokens": 200
+    },
+    {
         "product": "Smartcar",
         "website": "https://smartcar.com/",
         "llms-full-txt": "https://smartcar.com/docs/llms-full.txt",


### PR DESCRIPTION
Added Sherlock Domains to data.json.

> Sherlock is a domain registrar built specifically for AI agents, enabling them to search, buy and manage domains programmatically.

Happy to provide more info if needed.