### PR TITLE
add Cog

### DIFF
--- a/data.json
+++ b/data.json
@@ -96,6 +96,14 @@
         "llms-txt-tokens": 21788
     },
     {
+        "product": "Cog",
+        "website": "https://cog.run/",
+        "llms-full-txt": "",
+        "llms-full-txt-tokens": null,
+        "llms-txt": "https://cog.run/llms.txt",
+        "llms-txt-tokens": null
+    },
+    {
         "product": "CrewAI",
         "website": "https://crewai.com/",
         "llms-full-txt": "https://docs.crewai.com/llms-full.txt",


### PR DESCRIPTION
This PR adds an llms.txt for Cog, the open-source tool from Replicate for packing machine learning models in containers.

- https://cog.run
- https://cog.run/llms.txt