### PR TITLE
fix: merge apify entry into one

### DIFF
--- a/data.json
+++ b/data.json
@@ -34,16 +34,8 @@
     {
         "product": "Apify",
         "website": "https://apify.com/",
-        "llms-txt": "https://apify.com/llms.txt",
-        "llms-txt-tokens": 1764,
-        "llms-full-txt": "",
-        "llms-full-txt-tokens": null
-    },
-    {
-        "product": "Apify Documentation",
-        "website": "https://docs.apify.com/",
         "llms-txt": "https://docs.apify.com/llms.txt",
-        "llms-txt-tokens": 1038,
+        "llms-txt-tokens": 2503,
         "llms-full-txt": "",
         "llms-full-txt-tokens": null
     },


### PR DESCRIPTION
At Apify we decided to merge the two entries for both apify.com and docs.apify.com into single one.

Tokenization tested with [OpenAI's tokenizer](https://platform.openai.com/tokenizer).