### PR TITLE
Add fagaf.com to llms.txt directory

### DIFF
--- a/data.json
+++ b/data.json
@@ -232,6 +232,14 @@
         "llms-txt-tokens": 77790
     },
     {
+        "product": "fagaf.com",
+        "website": "https://www.fagaf.com/",
+        "llms-txt": "https://www.fagaf.com/llms.txt",
+        "llms-txt-tokens": null,
+        "llms-full-txt": "",
+        "llms-full-txt-tokens": null
+    },
+    {
         "product": "FastHTML",
         "website": "https://fastht.ml/",
         "llms-txt": "https://docs.fastht.ml/llms.txt",


### PR DESCRIPTION
This PR adds [fagaf.com](https://www.fagaf.com/)—a multilingual automotive community featuring articles, discussions, a glossary, and AI-friendly search tools—to the llms.txt directory.