### PR TITLE
Add llms.txt for Sourcegraph docs

### DIFF
--- a/data.json
+++ b/data.json
@@ -1059,5 +1059,13 @@
         "llms-txt-tokens": null,
         "llms-full-txt": "",
         "llms-full-txt-tokens": null
+    },
+   {
+        "product": "Sourcegraph",
+        "website": "https://sourcegraph.com/docs",
+        "llms-txt": "https://sourcegraph.com/docs/llms.txt",
+        "llms-txt-tokens": null,
+        "llms-full-txt": "",
+        "llms-full-txt-tokens": null
     }
 ]


### PR DESCRIPTION
This PR adds the `llms.txt` file for our Sourcegraph docs. I have tried to follow all the instructions mentioned in the Contributing section. 