### PR TITLE
Add Digital Middle Ground llms.txt entry

### DIFF
--- a/data.json
+++ b/data.json
@@ -8,6 +8,14 @@
         "llms-txt-tokens": null
    },
    {
+    "product": "Digital Middle Ground",
+    "website": "https://digitalmiddleground.com/",
+    "llms-full-txt": "",
+    "llms-full-txt-tokens": null,
+    "llms-txt": "https://www.digitalmiddleground.com/llms.txt",
+    "llms-txt-tokens": null
+},
+   {
         "product": "Himalayas",
         "website": "https://himalayas.app/",
         "llms-full-txt": "",


### PR DESCRIPTION
Added an entry in data.json for Digital Middle Ground with llms-full-txt empty and llms-txt pointing to our live llms.txt file. Left token fields as null as requested.