### PR TITLE
Add Tip.md to llms.txt directory

### DIFF
--- a/data.json
+++ b/data.json
@@ -1367,5 +1367,13 @@
       "llms-txt-tokens": null,
       "llms-full-txt": "https://docs.agentql.com/llms-full.txt",
       "llms-full-txt-tokens": 60771
+    },
+    {
+        "product": "Tip.md",
+        "website": "https://www.tip.md/",
+        "llms-full-txt": "",
+        "llms-full-txt-tokens": null,
+        "llms-txt": "https://www.tip.md/llms.txt",
+        "llms-txt-tokens": null
     }
 ]


### PR DESCRIPTION
This PR adds Tip.md to the llms.txt directory by including an entry in data.json with the necessary website and llms.txt links.

## About Tip.md
Tip.md is a markdown crypto tipping platform that enables developers to receive cryptocurrency tips (ETH, SOL, BTC) through embeddable buttons in markdown content

The platform provides:
- User-friendly interface for wallet setup and management
- Simple button generation for embedding in GitHub READMEs and websites
- Support for multiple blockchains

The llms.txt file provides structured information about Tip.md's core features and documentation for LLMs.
![Screenshot_2025-04-19 @ 23 50 55@2x](https://github.com/user-attachments/assets/57716fdf-5c8b-40d1-aff6-01704e4ea2aa)