### PR TITLE
Add llms-txt for theentresident.com

### DIFF
--- a/data.json
+++ b/data.json
@@ -1588,5 +1588,11 @@
         "website": "https://yoast.com/",
         "llms-full-txt": "",
         "llms-txt": "https://yoast.com/llms.txt"
+    },
+    {
+      "product": "The ENT Resident",
+      "website": "https://www.theentresident.com/",
+      "llms-full-txt": "",
+      "llms-txt": "https://www.theentresident.com/llms.txt",
     }
 ]


### PR DESCRIPTION
This PR adds an entry for The ENT Resident to the `data.json` file.

- `product`: "The ENT Resident"
- `website`: https://www.theentresident.com/
- `llms-txt`: https://www.theentresident.com/llms.txt
- `llms-full-txt`: left empty

Let me know if you'd like this structured any differently. Thanks!